### PR TITLE
Added 'Time' and 'Description' headers to the Day 1 card table.

### DIFF
--- a/samples/event-schedule/ac-qv-event.template.json
+++ b/samples/event-schedule/ac-qv-event.template.json
@@ -121,6 +121,42 @@
                     "weight": "Bolder",
                     "spacing": "Medium"
                 },
+                     {
+                    "type": "ColumnSet",
+                    "columns": [
+                        {
+                            "type": "Column",
+                            "width": 15,
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Time",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "color": "Accent",
+                                    "isSubtle": true,
+                                    "weight": "Bolder"
+                                }
+                            ]
+                        },
+                        {
+                            "type": "Column",
+                            "width": 65,
+                            "items": [
+                                {
+                                    "type": "TextBlock",
+                                    "text": "Description",
+                                    "wrap": true,
+                                    "size": "Small",
+                                    "color": "Accent",
+                                    "isSubtle": true,
+                                    "weight": "Bolder"
+                                }
+                            ]
+                        }
+                    ],
+                    "spacing": "Medium"
+                },
                 {
                     "type": "ColumnSet",
                     "$data": "${$root.days[0].entries}",


### PR DESCRIPTION
Added 'Time' and 'Description' headers to the Day 1 card table.

> By submitting this pull request, you agree to the [contribution guidelines](https://github.com/pnp/sp-dev-fx-extensions/blob/main/CONTRIBUTING.md)

> If you aren't familiar with how to contribute to open-source repositories using GitHub, or if you find the instructions on this page confusing, [sign up](https://forms.office.com/Pages/ResponsePage.aspx?id=KtIy2vgLW0SOgZbwvQuRaXDXyCl9DkBHq4A2OG7uLpdUREZVRDVYUUJLT1VNRDM4SjhGMlpUNzBORy4u) for one of our [Sharing is Caring](https://pnp.github.io/sharing-is-caring/#pnp-sic-events) events. It's completely free, and we'll guide you through the process.


|        Q        |                    A                    |
| --------------- | --------------------------------------- |
| Bug fix?        | yes                              |
| New feature?    | no                             |
| New sample?     | no                              |
| Related issues? | 

## What's in this Pull Request?

This pull request introduces a structured format to the Day 1 card by adding 'Time' and 'Description' headers to the table. This enhancement aims to improve readability and organization, making it easier for users to navigate and understand the schedule and activities listed for Day 1.

Changes:
- Inserted 'Time' header at the beginning of the table.
- Inserted 'Description' header following the 'Time' column.
- Adjusted table formatting to accommodate new headers.

The addition of these headers is a step towards a more user-friendly interface, ensuring that the information is presented clearly and concisely. Please review the changes and provide feedback.
